### PR TITLE
Add deployment clarification to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,11 @@ npm install
 cds watch bookstore
 ```
 
+### Deploy it
+
+This @capire/bookstore sample demonstrates the consumption of external services via the `ReviewsService` and `OrdersService`. Therefore, remove the `"kind": "odata"` entries in _package.json_ if you want to deploy this project as a _monolith_.
+
+To deploy the microservices separately in a _modulith_ deployment, refer to the enclosing [`samples`](https://github.com/capire/samples) monorepo and its deployment and pipeline configuration.
 
 ## License
 


### PR DESCRIPTION
As discussed in our UA sync recently, added deployment instructions for the bookstore sample, as the _package.json_ used here is not fit for deployment ootb due to the external services marked with `"kind": "odata"`.