### PR TITLE
chore: fix bookshop/bookstore tests

### DIFF
--- a/test/custom-handlers.test.js
+++ b/test/custom-handlers.test.js
@@ -5,9 +5,9 @@ cds.User.default = cds.User.Privileged // hard core monkey patch
 describe('cap/samples - Custom Handlers', () => {
 
   it('should reject out-of-stock orders', async () => {
-    await expect(POST `/browse/submitOrder ${{ book: 201, quantity: 5 }}`).to.be.fulfilled
-    await expect(POST `/browse/submitOrder ${{ book: 201, quantity: 5 }}`).to.be.fulfilled
-    await expect(POST `/browse/submitOrder ${{ book: 201, quantity: 5 }}`).to.be.rejectedWith(
+    await expect(POST `/odata/v4/browse/submitOrder ${{ book: 201, quantity: 5 }}`).to.be.fulfilled
+    await expect(POST `/odata/v4/browse/submitOrder ${{ book: 201, quantity: 5 }}`).to.be.fulfilled
+    await expect(POST `/odata/v4/browse/submitOrder ${{ book: 201, quantity: 5 }}`).to.be.rejectedWith(
       /409 - 5 exceeds stock for book #201/)
     const { data } = await GET`/admin/Books/201/stock/$value`
     expect(data).to.equal(2)

--- a/test/localized-data/services.test.js
+++ b/test/localized-data/services.test.js
@@ -5,12 +5,12 @@ cds.User.default = cds.User.Privileged // hard core monkey patch
 describe('cap/samples - Localized Data', () => {
 
   it('serves localized $metadata documents', async () => {
-    const { data } = await GET(`/browse/$metadata?sap-language=de`, { headers: { 'accept-language': 'de' }})
+    const { data } = await GET(`odata/v4/browse/$metadata?sap-language=de`, { headers: { 'accept-language': 'de' }})
     expect(data).to.contain('<Annotation Term="Common.Label" String="Währung"/>')
   })
 
   it('supports accept-language header', async () => {
-    const { data } = await GET(`/browse/Books?$select=title,author`, {
+    const { data } = await GET(`odata/v4/browse/Books?$select=title,author`, {
       headers: { 'Accept-Language': 'de' },
     })
     expect(data.value).to.containSubset([
@@ -23,7 +23,7 @@ describe('cap/samples - Localized Data', () => {
   })
 
   it('supports queries with $expand', async () => {
-    const { data } = await GET(`/browse/Books?&$select=title,author&$expand=currency`, {
+    const { data } = await GET(`/odata/v4/browse/Books?&$select=title,author&$expand=currency`, {
       headers: { 'Accept-Language': 'de' },
     })
     expect(data.value).to.containSubset([
@@ -65,7 +65,7 @@ describe('cap/samples - Localized Data', () => {
   })
 
   it('supports @cds.localized:false', async ()=>{
-    const { data } = await GET(`/browse/BooksSans?&$select=title,localized_title&$expand=currency&$filter=locale eq 'de' or locale eq null`, {
+    const { data } = await GET(`/odata/v4/browse/BooksSans?&$select=title,localized_title&$expand=currency&$filter=locale eq 'de' or locale eq null`, {
       headers: { 'Accept-Language': 'de' },
     })
     expect(data.value).to.containSubset([

--- a/test/odata.test.js
+++ b/test/odata.test.js
@@ -5,7 +5,7 @@ axios.defaults.auth = { username: 'alice', password: 'admin' }
 describe('cap/samples - Bookshop APIs', () => {
 
   it('serves $metadata documents in v4', async () => {
-    const { headers, status, data } = await GET `/browse/$metadata`
+    const { headers, status, data } = await GET `/odata/v4/browse/$metadata`
     expect(status).to.equal(200)
     expect(headers).to.contain({ 'odata-version': '4.0' })
     expect(headers['content-type']).to.match(/application\/xml/)
@@ -15,7 +15,7 @@ describe('cap/samples - Bookshop APIs', () => {
 
   it('serves Books?$expand=currency', async () => {
     const USD = { code: 'USD', name: 'US Dollar', descr: null, symbol: '$' }
-    const { data } = await GET `/browse/Books ${{
+    const { data } = await GET `/odata/v4/browse/Books ${{
       params: { $search: 'Po', $select: `title,author,genre`, $expand:`currency` },
     }}`
     expect(data.value).to.containSubset([
@@ -25,7 +25,7 @@ describe('cap/samples - Bookshop APIs', () => {
   })
 
   it('serves Books?$select=currency/code', async () => {
-    const { data } = await GET `/browse/Books ${{
+    const { data } = await GET `/odata/v4/browse/Books ${{
       params: { $search: 'Po', $select: `title,author,genre,currency/code` },
     }}`
     expect(data.value).to.containSubset([
@@ -37,7 +37,7 @@ describe('cap/samples - Bookshop APIs', () => {
   describe('query options...', () => {
 
     it('supports $search in multiple fields', async () => {
-      const { data } = await GET `/browse/Books ${{
+      const { data } = await GET `/odata/v4/browse/Books ${{
         params: { $search: 'Po', $select: `title,author` },
       }}`
       expect(data.value).to.containSubset([
@@ -49,7 +49,7 @@ describe('cap/samples - Bookshop APIs', () => {
     })
 
     it('supports $select', async () => {
-      const { data } = await GET(`/browse/Books`, {
+      const { data } = await GET(`/odata/v4/browse/Books`, {
         params: { $select: `ID,title` },
       })
       expect(data.value).to.containSubset([
@@ -82,13 +82,13 @@ describe('cap/samples - Bookshop APIs', () => {
     })
 
     it('supports $top/$skip paging', async () => {
-      const { data: p1 } = await GET`/browse/Books?$select=title&$top=3`
+      const { data: p1 } = await GET`/odata/v4/browse/Books?$select=title&$top=3`
       expect(p1.value).to.containSubset([
         { ID: 201, title: 'Wuthering Heights' },
         { ID: 207, title: 'Jane Eyre' },
         { ID: 251, title: 'The Raven' },
       ])
-      const { data: p2 } = await GET`/browse/Books?$select=title&$skip=3`
+      const { data: p2 } = await GET`/odata/v4/browse/Books?$select=title&$skip=3`
       expect(p2.value).to.containSubset([
         { ID: 252, title: 'Eleonora' },
         { ID: 271, title: 'Catweazle' },


### PR DESCRIPTION
Currently failing in matrix tests as the `/browse` route was changed in https://github.com/capire/bookshop/commit/b175e3e54fbf79c0d3c3bac79641aca84ebd9210.