### PR TITLE
Make header info of admin-service/books not editable

### DIFF
--- a/app/admin-books/webapp/manifest.json
+++ b/app/admin-books/webapp/manifest.json
@@ -107,6 +107,7 @@
                     "options": {
                         "settings" : {
                             "entitySet" : "Books",
+                            "editableHeaderContent": false,
                             "navigation" : {
                                 "Authors" : {
                                     "detail" : {


### PR DESCRIPTION
Fixes this:
<img width="931" height="706" alt="Screenshot 2026-06-02 at 12 47 01" src="https://github.com/user-attachments/assets/c9f421b3-0d55-4ca4-b4a9-677702188c97" />

by removing the editable header in admin-books. The title and author are already editable in the general section.
The other pages are ok with an editable header because they don't reference association.