### PR TITLE
use cds.odata.valuelist or raw odata annotation

### DIFF
--- a/app/admin-books/fiori-service.cds
+++ b/app/admin-books/fiori-service.cds
@@ -98,7 +98,21 @@ annotate AdminService.Books.texts with {
 // Add Value Help for Locales
 annotate AdminService.Books.texts {
 	locale @(
-		ValueList.entity:'Languages', Common.ValueListWithFixedValues, //show as drop down, not a dialog
+		Common.ValueList : {
+			CollectionPath: 'Languages',
+			Parameters                  : [
+				{
+					$Type            : 'Common.ValueListParameterDisplayOnly',
+					ValueListProperty: 'code',
+				},
+				{
+					$Type            : 'Common.ValueListParameterInOut',
+					LocalDataProperty:  locale,
+					ValueListProperty: 'code',
+				}
+			],
+		},
+		Common.ValueListWithFixedValues, //show as drop down, not a dialog
 	)
 }
 // In addition we need to expose Languages through AdminService as a target for ValueList

--- a/app/common.cds
+++ b/app/common.cds
@@ -34,8 +34,9 @@ annotate my.Books with @(
     Text: title,
     TextArrangement : #TextOnly
   };
-  author @ValueList.entity      : 'Authors';
 };
+
+annotate my.Authors with @cds.odata.valuelist;
 
 annotate common.Currencies with {
   symbol @Common.Label : '{i18n>Currency}';


### PR DESCRIPTION
Don't document `@ValueList.entity`, but only `@cds.odata.valuelist`.

The generated localization entities (`AdminService.Books.texts`) have the limitation that the `locale` is not actually an association. Since `cds.odata.valuelist` is registered on the association target, we need to fallback to the odata annotations.