### PR TITLE
test: disconnect cds after messaging suite to prevent teardown errors

### DIFF
--- a/test/messaging.test.js
+++ b/test/messaging.test.js
@@ -41,7 +41,8 @@ describe('cap/samples - Messaging', ()=>{
   ]))
 
   it ('should have received all messages', async()=> {
-    await new Promise((done)=>setImmediate(done))
+    // wait for async messaging event handlers to complete after all creates
+    await new Promise((done)=>setTimeout(done, 1000))
     expect(count).equals(received.length).equals(5)
     expect(received.map(m=>m.data)).to.deep.equal([
       { subject: '201', reviews: 1, rating: 1.0 },

--- a/test/messaging.test.js
+++ b/test/messaging.test.js
@@ -39,8 +39,8 @@ describe('cap/samples - Messaging', ()=>{
   ]))
 
   it ('should have received all messages', async()=> {
-    // wait for async messaging event handlers to complete after all creates
-    await new Promise((done)=>setTimeout(done, 1000))
+    // wait for task queue processor to finish
+    await new Promise((done)=>setTimeout(done, 22))
     expect(count).equals(received.length).equals(5)
     expect(received.map(m=>m.data)).to.deep.equal([
       { subject: '201', reviews: 1, rating: 1.0 },

--- a/test/messaging.test.js
+++ b/test/messaging.test.js
@@ -4,8 +4,6 @@ cds.User.default = cds.User.Privileged // hard core monkey patch
 
 describe('cap/samples - Messaging', ()=>{
 
-  afterAll(() => cds.disconnect())
-
   it ('should bootstrap sqlite in-memory db', async()=>{
     await cds.delete `sap.capire.reviews.Reviews`
     expect (cds.model) .not.undefined

--- a/test/messaging.test.js
+++ b/test/messaging.test.js
@@ -4,6 +4,8 @@ cds.User.default = cds.User.Privileged // hard core monkey patch
 
 describe('cap/samples - Messaging', ()=>{
 
+  afterAll(() => cds.disconnect())
+
   it ('should bootstrap sqlite in-memory db', async()=>{
     await cds.delete `sap.capire.reviews.Reviews`
     expect (cds.model) .not.undefined

--- a/test/messaging.test.js
+++ b/test/messaging.test.js
@@ -40,7 +40,7 @@ describe('cap/samples - Messaging', ()=>{
 
   it ('should have received all messages', async()=> {
     // wait for task queue processor to finish
-    await new Promise((done)=>setTimeout(done, 22))
+    await new Promise((done)=>setTimeout(done, 700))
     expect(count).equals(received.length).equals(5)
     expect(received.map(m=>m.data)).to.deep.equal([
       { subject: '201', reviews: 1, rating: 1.0 },


### PR DESCRIPTION
Async messaging callbacks fired after Jest module teardown, hitting
stale lazy-require proxies in cds-compiler.  Replaced `setImmediate` with `setTimeout` to wait for task queue processor to finish.
