### PR TITLE
showcase: tree view with direct crud 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Shows how to reuse and compose with CAP.",
   "repository": "https://github.com/capire/bookstore",
   "dependencies": {
+    "@sap/cds": ">=10",
     "@cap-js/hana": ">=1",
     "@capire/bookshop": "*",
     "@capire/common": "*",
@@ -35,6 +36,9 @@
           "model": "db/hana"
         }
       }
+    },
+    "fiori": {
+      "draft_new_action": true
     },
     "log": {
       "service": true

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "@capire/common": "*",
     "@capire/data-viewer": "*",
     "@capire/orders": "*",
-    "@capire/reviews": "*",
-    "@sap/cds": ">=8"
+    "@capire/reviews": "*"
   },
   "devDependencies": {
     "@cap-js/cds-test": "^1",


### PR DESCRIPTION
Successor of #24 

---

The installed Fiori Version still doesn't send the required binding parameter when using `draftNew`.

<img width="3357" height="699" alt="image" src="https://github.com/user-attachments/assets/c7bc9619-8271-4c8e-bed9-43e56f881713" />
